### PR TITLE
CI: flatpak action already upload the bundle

### DIFF
--- a/.github/workflows/build_flatpak.yml
+++ b/.github/workflows/build_flatpak.yml
@@ -24,9 +24,3 @@ jobs:
               with:
                   bundle: "soundux.flatpak"
                   manifest-path: "io.github.Soundux.yml"
-
-            - name: Upload Flatpak Artifact
-              uses: actions/upload-artifact@v2.2.2
-              with:
-                  name: Flatpak
-                  path: "soundux.flatpak"


### PR DESCRIPTION
No need to re-upload the bundle as it's done by the action itself if the build succeed