### PR TITLE
CI: use KDE image

### DIFF
--- a/.github/workflows/build_flatpak.yml
+++ b/.github/workflows/build_flatpak.yml
@@ -15,7 +15,7 @@ jobs:
     flatpak-builder:
         runs-on: ubuntu-20.04
         container:
-            image: docker.io/bilelmoussaoui/flatpak-github-actions
+            image: bilelmoussaoui/flatpak-github-actions:kde-5.15
             options: --privileged
 
         steps:


### PR DESCRIPTION
The KDE image comes with the 5.15 version pre-installed, it should reduce the CI time considerably 

Details at https://github.com/bilelmoussaoui/flatpak-github-actions#docker-image