### PR TITLE
CI: update flatpak job

### DIFF
--- a/.github/workflows/build_flatpak.yml
+++ b/.github/workflows/build_flatpak.yml
@@ -23,8 +23,7 @@ jobs:
               with:
                   submodules: true
             - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
-              with:
-                  cache: true
-                  cache-key: flatpak-builder-${sha256(deployment/flatpak/io.github.Soundux.yml)}
+              with:          
+                  cache-key: flatpak-builder-${{ github.sha }}
                   bundle: "soundux.flatpak"
                   manifest-path: "deployment/flatpak/io.github.Soundux.yml"


### PR DESCRIPTION
- cache is enabled by default
- cache-key needs to be set to something that will change for every commit otherwise github fails to upload a cache for it, it's an upstream issue.

Regarding the cache-key, once the upstream issue is fixed, you can completely drop it as the default one is good enough. 