### PR TITLE
Unload problematic modules automatically (PulseAudio)

### DIFF
--- a/src/helper/audio/linux/backend.cpp
+++ b/src/helper/audio/linux/backend.cpp
@@ -19,23 +19,15 @@ namespace Soundux::Objects
 
             if (pulseInstance && pulseInstance->setup())
             {
-                if (!pulseInstance->switchOnConnectPresent())
+                if (pulseInstance->isRunningPipeWire())
                 {
-                    if (pulseInstance->loadModules())
-                    {
-                        return instance;
-                    }
+                    backend = Enums::BackendType::PipeWire;
+                    Globals::gSettings.audioBackend = backend;
                 }
                 else
                 {
                     return instance;
                 }
-            }
-
-            if (pulseInstance && pulseInstance->isRunningPipeWire())
-            {
-                backend = Enums::BackendType::PipeWire;
-                Globals::gSettings.audioBackend = backend;
             }
         }
 

--- a/src/helper/audio/linux/backend.cpp
+++ b/src/helper/audio/linux/backend.cpp
@@ -23,6 +23,9 @@ namespace Soundux::Objects
                 {
                     backend = Enums::BackendType::PipeWire;
                     Globals::gSettings.audioBackend = backend;
+
+                    pulseInstance->destroy();
+                    pulseInstance.reset();
                 }
                 else
                 {

--- a/src/helper/audio/linux/pulseaudio/pulseaudio.hpp
+++ b/src/helper/audio/linux/pulseaudio/pulseaudio.hpp
@@ -27,6 +27,12 @@ namespace Soundux
             ~PulseRecordingApp() override = default;
         };
 
+        struct PulseModule
+        {
+            std::string name;
+            std::string arguments;
+        };
+
         class PulseAudio : public AudioBackend
         {
             friend class AudioBackend;
@@ -47,6 +53,7 @@ namespace Soundux
             //* ~= ~~~~~~~~~~~~~~~~~~~~~ =~
 
             std::string serverName;
+            std::vector<PulseModule> unloadedModules;
 
             std::string defaultSource;
             std::optional<std::uint32_t> defaultSourceId;
@@ -56,10 +63,14 @@ namespace Soundux
 
             std::mutex operationMutex;
 
+            bool loadModules();
             void unloadLeftOvers();
             void fetchDefaultSource();
             void fetchLoopBackSinkId();
             void await(pa_operation *);
+
+            void unloadProblematic();
+            void reloadProblematic();
 
             void fixPlaybackApps(const std::vector<std::shared_ptr<PlaybackApp>> &);
             void fixRecordingApps(const std::vector<std::shared_ptr<RecordingApp>> &);
@@ -68,9 +79,6 @@ namespace Soundux
             bool setup() override;
 
           public:
-            //! Is not ran by default to avoid problems with switch-on-connect
-            bool loadModules();
-
             void destroy() override;
             bool isRunningPipeWire();
 
@@ -87,9 +95,6 @@ namespace Soundux
 
             bool stopSoundInput() override;
             bool inputSoundTo(std::shared_ptr<RecordingApp> app) override;
-
-            void unloadSwitchOnConnect();
-            bool switchOnConnectPresent();
 
             std::shared_ptr<PlaybackApp> getPlaybackApp(const std::string &application) override;
             std::shared_ptr<RecordingApp> getRecordingApp(const std::string &application) override;

--- a/src/ui/impl/webview/webview.hpp
+++ b/src/ui/impl/webview/webview.hpp
@@ -34,7 +34,6 @@ namespace Soundux
             void onSettingsChanged() override;
             void onLocalVolumeChanged(int volume) override;
             void onRemoteVolumeChanged(int volume) override;
-            void onSwitchOnConnectDetected(bool state) override;
             void onError(const Enums::ErrorCode &error) override;
             void onSoundPlayed(const PlayingSound &sound) override;
             void onSoundProgressed(const PlayingSound &sound) override;

--- a/src/ui/ui.hpp
+++ b/src/ui/ui.hpp
@@ -103,7 +103,6 @@ namespace Soundux
             virtual void onSettingsChanged() = 0;
             virtual void onLocalVolumeChanged(int) = 0;
             virtual void onRemoteVolumeChanged(int) = 0;
-            virtual void onSwitchOnConnectDetected(bool) = 0;
             virtual void onSoundPlayed(const PlayingSound &);
             virtual void onError(const Enums::ErrorCode &) = 0;
             virtual void onSoundFinished(const PlayingSound &);


### PR DESCRIPTION
This change implements some changes to how we handle problematic modules proposed by @D3SOX.

## The Problem
Currently we only detect if the `switch-on-connect` module is loaded and if so we prompt the user to unload it.  
However the module `role-cork` is also causing problems.  
Adding a detection for that modules would require us to show the user yet another prompt.  

There are different scenarios on how this impacts users:
- Users without much knowledge
    - May be intimidated by a big red prompt telling them they have to unload the module
- Users that don't want to permanently disable the module / Users that don't know how to <sub><sup>(in case they didn't read our wiki entry regarding this issue)</sub></sup>
    - Always have to click through the prompts on start up and are required to reload the modules themselves after soundux exits
    
## Proposed Solution
Our proposed solution is to automatically unload those modules from soundux and reload them once soundux exits.  
That way the user is not required to click through dozens of prompts to use the application and continue to make use of the problematic modules after soundux exits.

## Possible Improvements
- Notify the user about what we do, in form of a prompt in the frontend (@D3SOX ?) - So that the user doesn't experience problems without knowing where they come from (in this case they may be caused because we unloaded some modules)