### PR TITLE
fix(pulseaudio): mute the default audio source directly

### DIFF
--- a/src/helper/audio/linux/pulseaudio/forward.cpp
+++ b/src/helper/audio/linux/pulseaudio/forward.cpp
@@ -37,7 +37,7 @@ bool Soundux::PulseApi::setup()
     load(context_move_sink_input_by_index);
     load(context_move_source_output_by_name);
     load(context_move_source_output_by_index);
-    load(context_set_sink_input_mute);
+    load(context_set_source_mute_by_name);
     load(context_unload_module);
     load(context_get_state);
     load(operation_get_state);
@@ -69,7 +69,7 @@ bool Soundux::PulseApi::setup()
             load(context_move_sink_input_by_index);
             load(context_move_source_output_by_name);
             load(context_move_source_output_by_index);
-            load(context_set_sink_input_mute);
+            load(context_set_source_mute_by_name);
             load(context_unload_module);
             load(context_get_state);
             load(operation_get_state);

--- a/src/helper/audio/linux/pulseaudio/forward.hpp
+++ b/src/helper/audio/linux/pulseaudio/forward.hpp
@@ -26,9 +26,9 @@ namespace Soundux
         pulse_forward_decl(context_get_server_info);
         pulse_forward_decl(context_set_state_callback);
         pulse_forward_decl(context_set_default_source);
-        pulse_forward_decl(context_set_sink_input_mute);
         pulse_forward_decl(context_get_module_info_list);
         pulse_forward_decl(context_move_sink_input_by_name);
+        pulse_forward_decl(context_set_source_mute_by_name);
         pulse_forward_decl(context_move_sink_input_by_index);
         pulse_forward_decl(context_get_sink_input_info_list);
         pulse_forward_decl(context_move_source_output_by_name);

--- a/src/helper/audio/linux/pulseaudio/pulseaudio.cpp
+++ b/src/helper/audio/linux/pulseaudio/pulseaudio.cpp
@@ -144,8 +144,7 @@ namespace Soundux::Objects
 
         fetchLoopBackSinkId();
 
-        if (!nullSink || !loopBack || !loopBackSink || !passthrough || !passthroughSink || !passthroughLoopBack ||
-            !defaultSourceId)
+        if (!nullSink || !loopBack || !loopBackSink || !passthrough || !passthroughSink || !passthroughLoopBack)
         {
             unloadLeftOvers();
             return false;
@@ -193,17 +192,6 @@ namespace Soundux::Objects
                 {
                     reinterpret_cast<PulseAudio *>(userData)->defaultSource = info->default_source_name;
                     reinterpret_cast<PulseAudio *>(userData)->serverName = info->server_name;
-                }
-            },
-            this));
-        await(PulseApi::context_get_sink_input_info_list(
-            context,
-            []([[maybe_unused]] pa_context *ctx, const pa_sink_input_info *info, [[maybe_unused]] int eol,
-               void *userData) {
-                auto *thiz = reinterpret_cast<PulseAudio *>(userData);
-                if (info && info->name == thiz->defaultSource)
-                {
-                    thiz->defaultSourceId = info->index;
                 }
             },
             this));
@@ -644,8 +632,8 @@ namespace Soundux::Objects
     {
         bool success = false;
 
-        await(PulseApi::context_set_sink_input_mute(
-            context, *defaultSourceId, state,
+        await(PulseApi::context_set_source_mute_by_name(
+            context, defaultSource.c_str(), state,
             +[]([[maybe_unused]] pa_context *ctx, int success, void *userData) {
                 *reinterpret_cast<bool *>(userData) = success;
             },
@@ -653,7 +641,7 @@ namespace Soundux::Objects
 
         if (!success)
         {
-            Fancy::fancy.logTime().failure() << "Failed to mute loopback sink" << std::endl;
+            Fancy::fancy.logTime().failure() << "Failed to mute default source" << std::endl;
         }
 
         return success;

--- a/src/helper/audio/linux/pulseaudio/pulseaudio.hpp
+++ b/src/helper/audio/linux/pulseaudio/pulseaudio.hpp
@@ -49,7 +49,6 @@ namespace Soundux
             std::string serverName;
 
             std::string defaultSource;
-            std::optional<std::uint32_t> defaultSourceId;
 
             std::map<std::string, std::uint32_t> movedApplications;
             std::map<std::string, std::uint32_t> movedPassthroughApplications;


### PR DESCRIPTION
## Motivation and Context
Commit e4bfce692fa8d325e9ee5c9e8b040cc01e319abe broke PulseAudio support for me (and I'm guessing a few other people); the local source has a name of "alsa_input.pci-0000_00_1f.3.analog-stereo", but the sink input list only had various other devices I have in the house with PulseAudio forwarding switched on (e.g. "Built-in Audio Analog Stereo for scott@hoagie"). As such, defaultSourceId would never be populated as there wasn't a matching name, and the PulseAudio backend would fail to start.

At a guess, I think the original intention of the commit was to mute the default source (aka. whatever PulseAudio has chosen to be the current mic), instead of the sink input to the loopback device. So this patch provides that change.

## How Has This Been Tested?
Soundux starts, PulseAudio works. Ran Soundux with the "Mute microphone during playback" feature switched on and off. Microphone source gets muted/unmuted as expected.

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [Contributing Guidelines](https://github.com/Soundux/Soundux/blob/master/CONTRIBUTING.md#code) (including code style) of this project.
- [ ] My change requires a change to the documentation.