### PR TITLE
metadata: Small fixes

### DIFF
--- a/deployment/appstream/io.github.Soundux.metainfo.xml
+++ b/deployment/appstream/io.github.Soundux.metainfo.xml
@@ -12,6 +12,7 @@
   <url type="donation">https://ko-fi.com/soundux/</url>
   <url type="bugtracker">https://github.com/Soundux/Soundux/issues</url>
   <url type="help">https://github.com/Soundux/Soundux/issues</url>
+  <url type="vcs-browser">https://github.com/Soundux/Soundux</url>
   <description>
     <p>
       A universal soundboard that uses PulseAudio modules or PipeWire linking
@@ -29,13 +30,6 @@
     </ul>
   </description>
 
-  <launchable type="desktop-id">
-    io.github.Soundux.desktop
-  </launchable>
-  <categories>
-    <category>AudioVideo</category>
-    <category>Audio</category>
-  </categories>
   <screenshots>
     <screenshot type="default">
       <caption>Dark Interface</caption>


### PR DESCRIPTION
- Add vcs-browser URL
- Remove the duplicated launchable tag
- Remove the categories  from the metainfo.xml

> **Categories and keywords**
> If there’s a [launchable](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#launchable) defined for a desktop application, categories and keywords are pulled from the desktop file. Defining them separately in the Metainfo file will override the contents of the desktop file.

More info: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#categories-and-keywords
